### PR TITLE
user/pass attributes for BaseHttpTarget consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [v1.04] - 4/8/2022
+### Changed
+- Fixed bug related to spray modules inheriting methods from BaseHttpTarget parent that refereced vars not set in formdata
+
 ## [v1.03] - 3/29/2022
 ### Added
 - Okta target module (needs testing)

--- a/spraycharles.py
+++ b/spraycharles.py
@@ -24,7 +24,7 @@ from rich.theme import Theme
 from analyze import Analyzer
 from targets import *
 
-VERSION = 1.03
+VERSION = 1.04
 
 # Defining theme
 custom_theme = Theme(

--- a/targets/Adfs.py
+++ b/targets/Adfs.py
@@ -44,9 +44,11 @@ class Adfs(BaseHttpTarget):
 
     def set_username(self, username):
         self.data["UserName"] = username
+        self.username = username
 
     def set_password(self, password):
         self.data["Password"] = password
+        self.password = password
 
     def login(self, username, password):
         # set data

--- a/targets/Ciscosslvpn.py
+++ b/targets/Ciscosslvpn.py
@@ -50,9 +50,11 @@ class Ciscosslvpn(BaseHttpTarget):
 
     def set_username(self, username):
         self.data["username"] = username
+        self.username = username
 
     def set_password(self, password):
         self.data["password"] = password
+        self.password = password
 
     def login(self, username, password):
         # set data

--- a/targets/Citrix.py
+++ b/targets/Citrix.py
@@ -43,9 +43,11 @@ class Citrix(BaseHttpTarget):
 
     def set_username(self, username):
         self.data["login"] = username
+        self.username = username
 
     def set_password(self, password):
         self.data["passwd"] = password
+        self.password = password
 
     def login(self, username, password):
         # set data

--- a/targets/Ntlm.py
+++ b/targets/Ntlm.py
@@ -36,9 +36,11 @@ class Ntlm(BaseHttpTarget):
 
     def set_username(self, username):
         self.data["username"] = username
+        self.username = username
 
     def set_password(self, password):
         self.data["password"] = password
+        self.password = password
 
     def login(self, username, password):
         self.set_username(username)

--- a/targets/Owa.py
+++ b/targets/Owa.py
@@ -49,9 +49,11 @@ class Owa(BaseHttpTarget):
 
     def set_username(self, username):
         self.data["username"] = username
+        self.username = username
 
     def set_password(self, password):
         self.data["password"] = password
+        self.password = password
 
     def login(self, username, password):
         # set data

--- a/targets/Sonicwall.py
+++ b/targets/Sonicwall.py
@@ -48,9 +48,11 @@ class Sonicwall(BaseHttpTarget):
 
     def set_username(self, username):
         self.data["uName"] = username
+        self.username = username
 
     def set_password(self, password):
         self.data["pass"] = password
+        self.password = password
 
     def login(self, username, password):
         # set data

--- a/targets/classes/BaseHttpTarget.py
+++ b/targets/classes/BaseHttpTarget.py
@@ -6,6 +6,10 @@ class BaseHttpTarget:
     Base class to hold output for standard HTTP spray targets
     """
 
+    def __init__(self):
+        self.username = ""
+        self.password = ""
+
     # handle CSV out output headers. Can be customized per module
     def print_headers(self, csvfile):
         """
@@ -36,14 +40,9 @@ class BaseHttpTarget:
             length = str(len(response.content))
 
         # print result to screen
-        print(
-            "%-35s %-17s %13s %15s"
-            % (self.data["username"], self.data["password"], code, length)
-        )
+        print("%-35s %-17s %13s %15s" % (self.username, self.password, code, length))
 
         # print to CSV file
         output = open(csvfile, "a")
-        output.write(
-            f'{self.data["username"]},{self.data["password"]},{code},{length}\n'
-        )
+        output.write(f"{self.username},{self.password},{code},{length}\n")
         output.close()


### PR DESCRIPTION
Tracking for bug in #14. Formdata user/pass variable names are not the same across all modules causing the parent class to error. Setup class attributes to handle this instead of the formdata dict