### PR TITLE
Fix/smb conn error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [v0.1.0.10] - 6/20/2024
+### Fixed
+- Catch OSError that gets thrown on SMB connection timeouts ([#23](https://github.com/Tw1sm/spraycharles/issues/23))
 
 ## [v1.0.9] - 6/23/2022
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spraycharles"
-version = "1.0.9"
+version = "1.0.10"
 description = "Low and slow password spraying tool, designed to spray on an interval over a long period of time."
 authors = [
     "Matt Creel",

--- a/spraycharles/__init__.py
+++ b/spraycharles/__init__.py
@@ -1,7 +1,7 @@
 from rich.console import Console
 from rich.theme import Theme
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 
 # Defining theme
 custom_theme = Theme(

--- a/spraycharles/spraycharles.py
+++ b/spraycharles/spraycharles.py
@@ -377,8 +377,8 @@ class Spraycharles:
             response = self.target.login(username, password)
             self.target.print_response(response, self.output)
         except requests.ConnectTimeout as e:
-            self.target.print_response(response, self.output, timeout=True)
-        except (requests.ConnectionError, requests.ReadTimeout) as e:
+            self.target.print_response(None, self.output, timeout=True)
+        except (requests.ConnectionError, requests.ReadTimeout, OSError) as e:
             console.print(
                 "\n[!] Connection error - sleeping for 5 seconds", style="danger"
             )


### PR DESCRIPTION
Catch `OSError` thrown when the SMB module experiences a connection timeout. Code now enters the same 5 second wait/retry loop that HTTP modules leverage

Specifically addresses #23 